### PR TITLE
Configure Dependabot for Cargo with daily updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "cargo" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 15
+  #- package-ecosystem: "docker"
+  #  directory: "/"
+  #  schedule:
+  #    interval: "weekly"
+  #- package-ecosystem: "github-actions"
+  #  directory: "/"
+  #  schedule:
+  #    interval: "weekly"


### PR DESCRIPTION
Updated package ecosystem to 'cargo' and changed update schedule to daily with a cooldown period.